### PR TITLE
return bool from read_pin()

### DIFF
--- a/adafruit_pcf8574.py
+++ b/adafruit_pcf8574.py
@@ -90,7 +90,7 @@ class PCF8574:
 
     def read_pin(self, pin: int) -> bool:
         """Read a single GPIO pin as high/pulled-up or driven low"""
-        return bool((self.read_gpio() >> pin) & 0x1)
+        return ((self.read_gpio() >> pin) & 0x1) == 1
 
 
 """

--- a/adafruit_pcf8574.py
+++ b/adafruit_pcf8574.py
@@ -90,7 +90,7 @@ class PCF8574:
 
     def read_pin(self, pin: int) -> bool:
         """Read a single GPIO pin as high/pulled-up or driven low"""
-        return (self.read_gpio() >> pin) & 0x1
+        return bool((self.read_gpio() >> pin) & 0x1)
 
 
 """


### PR DESCRIPTION
@ladyada 

It was mentioned in https://github.com/adafruit/Adafruit_CircuitPython_PCF8575/issues/6 that this library had the same differing return type. This is the same fix as from that repo.